### PR TITLE
return the max status code from running tests

### DIFF
--- a/dotnet-test.ps1
+++ b/dotnet-test.ps1
@@ -1,11 +1,16 @@
+$exitCode = 0;
+
 if(Test-Path -Path 'application/test/') {
   Get-ChildItem application/test/ -Recurse -include project.json | ForEach {
     $parent = Split-Path (Split-Path -Path $_.Fullname -Parent) -Leaf;
     $testFile = "TEST-RESULTS-$parent.xml";
     dotnet test $_.Fullname -xml $testFile;
+    $exitCode = [System.Math]::Max($lastExitCode, $exitCode);
   }
 }
 else
 {
   Write-Warning "No test file found.  Skipping tests."
 }
+
+exit $exitCode;


### PR DESCRIPTION
this is so we can still ignore standard errors in tests and fail when tests fail
